### PR TITLE
Avoid passing loop argument to some asyncio methods

### DIFF
--- a/telethon/client/dialogs.py
+++ b/telethon/client/dialogs.py
@@ -378,7 +378,7 @@ class DialogMethods:
             entities = [await self.get_input_entity(entity)]
         else:
             entities = await asyncio.gather(
-                *(self.get_input_entity(x) for x in entity), loop=self.loop)
+                *(self.get_input_entity(x) for x in entity))
 
         if folder is None:
             raise ValueError('You must specify a folder')

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -318,15 +318,15 @@ class TelegramBaseClient(abc.ABC):
         # being ``n`` the amount of borrows a given sender has; once ``n``
         # reaches ``0`` it should be disconnected and removed.
         self._borrowed_senders = {}
-        self._borrow_sender_lock = asyncio.Lock(loop=self._loop)
+        self._borrow_sender_lock = asyncio.Lock()
 
         self._updates_handle = None
         self._last_request = time.time()
         self._channel_pts = {}
 
         if sequential_updates:
-            self._updates_queue = asyncio.Queue(loop=self._loop)
-            self._dispatching_updates_queue = asyncio.Event(loop=self._loop)
+            self._updates_queue = asyncio.Queue()
+            self._dispatching_updates_queue = asyncio.Event()
         else:
             # Use a set of pending instead of a queue so we can properly
             # terminate all pending updates on disconnect.
@@ -506,7 +506,7 @@ class TelegramBaseClient(abc.ABC):
             for task in self._updates_queue:
                 task.cancel()
 
-            await asyncio.wait(self._updates_queue, loop=self._loop)
+            await asyncio.wait(self._updates_queue)
             self._updates_queue.clear()
 
         pts, date = self._state_cache[None]

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -325,7 +325,7 @@ class UpdateMethods:
         while self.is_connected():
             try:
                 await asyncio.wait_for(
-                    self.disconnected, timeout=60, loop=self._loop
+                    self.disconnected, timeout=60
                 )
                 continue  # We actually just want to act upon timeout
             except asyncio.TimeoutError:

--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -41,7 +41,7 @@ class UserMethods:
                     self._flood_waited_requests.pop(r.CONSTRUCTOR_ID, None)
                 elif diff <= self.flood_sleep_threshold:
                     self._log[__name__].info(*_fmt_flood(diff, r, early=True))
-                    await asyncio.sleep(diff, loop=self._loop)
+                    await asyncio.sleep(diff)
                     self._flood_waited_requests.pop(r.CONSTRUCTOR_ID, None)
                 else:
                     raise errors.FloodWaitError(request=r, capture=diff)
@@ -91,7 +91,7 @@ class UserMethods:
 
                 if e.seconds <= self.flood_sleep_threshold:
                     self._log[__name__].info(*_fmt_flood(e.seconds, request))
-                    await asyncio.sleep(e.seconds, loop=self._loop)
+                    await asyncio.sleep(e.seconds)
                 else:
                     raise
             except (errors.PhoneMigrateError, errors.NetworkMigrateError,

--- a/telethon/events/common.py
+++ b/telethon/events/common.py
@@ -93,7 +93,7 @@ class EventBuilder(abc.ABC):
             return
 
         if not self._resolve_lock:
-            self._resolve_lock = asyncio.Lock(loop=client.loop)
+            self._resolve_lock = asyncio.Lock()
 
         async with self._resolve_lock:
             if not self.resolved:

--- a/telethon/events/inlinequery.py
+++ b/telethon/events/inlinequery.py
@@ -209,7 +209,7 @@ class InlineQuery(EventBuilder):
                 futures = [self._as_future(x, self._client.loop)
                            for x in results]
 
-                await asyncio.wait(futures, loop=self._client.loop)
+                await asyncio.wait(futures)
 
                 # All futures will be in the `done` *set* that `wait` returns.
                 #

--- a/telethon/extensions/messagepacker.py
+++ b/telethon/extensions/messagepacker.py
@@ -26,7 +26,7 @@ class MessagePacker:
         self._state = state
         self._loop = loop
         self._deque = collections.deque()
-        self._ready = asyncio.Event(loop=loop)
+        self._ready = asyncio.Event()
         self._log = loggers[__name__]
 
     def append(self, state):

--- a/telethon/network/connection/connection.py
+++ b/telethon/network/connection/connection.py
@@ -50,7 +50,7 @@ class Connection(abc.ABC):
             self._reader, self._writer = await asyncio.wait_for(
                 asyncio.open_connection(
                     self._ip, self._port, loop=self._loop, ssl=ssl),
-                loop=self._loop, timeout=timeout
+                timeout=timeout
             )
         else:
             import socks
@@ -68,8 +68,7 @@ class Connection(abc.ABC):
             s.setblocking(False)
             await asyncio.wait_for(
                 self._loop.sock_connect(s, address),
-                timeout=timeout,
-                loop=self._loop
+                timeout=timeout
             )
             if ssl:
                 if ssl_mod is None:

--- a/telethon/network/mtprotosender.py
+++ b/telethon/network/mtprotosender.py
@@ -55,7 +55,7 @@ class MTProtoSender:
         self._auth_key_callback = auth_key_callback
         self._update_callback = update_callback
         self._auto_reconnect_callback = auto_reconnect_callback
-        self._connect_lock = asyncio.Lock(loop=loop)
+        self._connect_lock = asyncio.Lock()
 
         # Whether the user has explicitly connected or disconnected.
         #
@@ -206,7 +206,7 @@ class MTProtoSender:
         Note that it may resolve in either a ``ConnectionError``
         or any other unexpected error that could not be handled.
         """
-        return asyncio.shield(self._disconnected, loop=self._loop)
+        return asyncio.shield(self._disconnected)
 
     # Private methods
 
@@ -241,7 +241,7 @@ class MTProtoSender:
                     # reconnect cleanly after.
                     await self._connection.disconnect()
                     connected = False
-                    await asyncio.sleep(self._delay, loop=self._loop)
+                    await asyncio.sleep(self._delay)
                     continue  # next iteration we will try to reconnect
 
             break  # all steps done, break retry loop

--- a/telethon/requestiter.py
+++ b/telethon/requestiter.py
@@ -64,10 +64,7 @@ class RequestIter(abc.ABC):
         if self.index == len(self.buffer):
             # asyncio will handle times <= 0 to sleep 0 seconds
             if self.wait_time:
-                await asyncio.sleep(
-                    self.wait_time - (time.time() - self.last_load),
-                    loop=self.client.loop
-                )
+                await asyncio.sleep(self.wait_time - (time.time() - self.last_load))
                 self.last_load = time.time()
 
             self.index = 0

--- a/telethon/tl/custom/conversation.py
+++ b/telethon/tl/custom/conversation.py
@@ -397,8 +397,7 @@ class Conversation(ChatGetter):
         #       cleared when their futures are set to a result.
         return asyncio.wait_for(
             future,
-            timeout=None if due == float('inf') else due - time.time(),
-            loop=self._client.loop
+            timeout=None if due == float('inf') else due - time.time()
         )
 
     def _cancel_all(self, exception=None):


### PR DESCRIPTION
Since this behaviour is now deprecated, as per
https://docs.python.org/3.9/whatsnew/3.8.html#deprecated. Notably,
some methods still require the argument.

Fixes #1395.